### PR TITLE
Fixing order of commands for prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ cd acm-ansible-collection-demo
 export CONTROLLER_HOST=<ansible automation controller URL>
 export CONTROLLER_USERNAME=<username>
 export CONTROLLER_PASSWORD=<password>
-export CONTROLLER_TOKEN=`awx login | jq -r .token`
 export CONTROLLER_VERIFY_SSL=no
+export CONTROLLER_TOKEN=`awx login | jq -r .token`
 ```
 
 #### Set up environment variables for ACM Ansible Collection modules


### PR DESCRIPTION
Under the "Set up environment variables for Ansible Automation Controller" section:
Command "export CONTROLLER_VERIFY_SSL=no" needs to be run first in order to "export CONTROLLER_TOKEN=`awx login | jq -r .token`" work as well