### PR TITLE
update stolostron collection requirement to v0.0.2

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,5 +1,5 @@
 collections:
 - name: stolostron.core
-  version: 0.0.1
+  version: 0.0.2
 - name: kubernetes.core
 - name: awx.awx


### PR DESCRIPTION
fixes https://github.com/stolostron/acm-ansible-collection-demo/issues/11

for compatibility with ACM 2.6.x